### PR TITLE
Implement Video Speed Playback

### DIFF
--- a/src/recur.cpp
+++ b/src/recur.cpp
@@ -5,6 +5,11 @@ void recur::setup(string playerType){
     aPlayer.setup(playerType, "a");
     bPlayer.setup(playerType, "b");
 
+    currentSpeed = 1.0f;
+    currentSpeedBucket = 2;
+    speedPotActive = false;
+    initialSpeedPotValue = -1.0f;
+
     /*isLoopSeamless = true;
 
     if(isLoopSeamless == true){
@@ -71,6 +76,7 @@ void recur::updateSeamless(){
         if(aPlayer.status == "FINISHED" && bPlayer.status == "LOADED"){
             nowPlaying = "b";
             bPlayer.playPlayer();
+            bPlayer.setSpeedTo(currentSpeed);
             bPlayer.status = "PLAYING";
             aPlayer.loadPlayer(videoPath);
             aPlayer.status = "LOADING";
@@ -85,6 +91,7 @@ void recur::updateSeamless(){
         if(bPlayer.status == "FINISHED" && aPlayer.status == "LOADED"){
             nowPlaying = "a";
             aPlayer.playPlayer();
+            aPlayer.setSpeedTo(currentSpeed);
             aPlayer.status = "PLAYING";
             bPlayer.loadPlayer(videoPath);
             bPlayer.status = "LOADING";
@@ -106,6 +113,7 @@ void recur::updateSingle(){
 
     if(aPlayer.status == "LOADED"){
         aPlayer.playPlayer();
+        aPlayer.setSpeedTo(currentSpeed);
         aPlayer.status = "PLAYING";
     }
 
@@ -168,6 +176,63 @@ void recur::setPlay(bool play){
         if(play){bPlayer.playPlayer(); }
         else{bPlayer.pausePlayer(); }
     }
+}
+
+void recur::setSpeed(float normalizedPot) {
+
+    int rawBucket = (int)(normalizedPot * 5);
+
+    int speedBucket = ofClamp(rawBucket, 0, 4);
+
+    float speedMultipliers[5] = {0.25f, 0.5f, 1.0f, 2.0f, 4.0f};
+
+    float speed = speedMultipliers[speedBucket];
+
+    float speedBucketSize = 0.2;
+    // Amount of pot change before we actually change the speed, to avoid flapping on boundaries
+    float speedChangeMargin = 0.02;
+
+    // User hasn't used the speed pot yet after boot, keep speed at 1x default
+    if (speedPotActive == false)  {
+
+        if (initialSpeedPotValue < 0) {
+            initialSpeedPotValue = normalizedPot;
+            return;
+        }
+        
+        if (initialSpeedPotValue >= 0) {
+            float potDiff = abs(normalizedPot - initialSpeedPotValue);
+
+            // User moved the pot enough to activate (5%), now start reading it
+            if (potDiff > 0.05) {
+                speedPotActive = true;
+            }
+
+        } else {
+            return;
+        }
+        
+    }
+
+    if (speedBucket == this->currentSpeedBucket) {
+        return;
+    } else {
+        float potDriftLowBoundary = (currentSpeedBucket * speedBucketSize) - speedChangeMargin;
+
+        float potDriftHighBoundary = ((currentSpeedBucket + 1) * speedBucketSize) + speedChangeMargin;
+
+        // Pot change too small (< 2%) to change speed, keep the same speed
+        if (normalizedPot > potDriftLowBoundary && normalizedPot < potDriftHighBoundary) {
+            return;
+        }
+        
+        this->currentSpeedBucket = speedBucket;
+        this->currentSpeed = speed;
+
+        aPlayer.setSpeedTo(speed);
+        bPlayer.setSpeedTo(speed);
+    }
+
 }
 
 void recur::closeAll(){

--- a/src/recur.h
+++ b/src/recur.h
@@ -26,6 +26,12 @@ class recur {
         void startSingle(string path);
         void updateSingle();
 
+        void setSpeed(float normalizedPot);
+        float currentSpeed;
+        int currentSpeedBucket;
+        bool speedPotActive;
+        float initialSpeedPotValue;
+
         void closeAll();
         string nowPlaying;
         string videoPath;

--- a/src/recurVideoPlayer.cpp
+++ b/src/recurVideoPlayer.cpp
@@ -66,10 +66,8 @@ void recurVideoPlayer::setSpeedTo(float speedValue){
     #ifdef TARGET_RASPBERRY_PI
     float mappedSpeedValue =  DVD_PLAYSPEED_NORMAL * speed; // Map speed to OMX ranges (1x = 1000)
     
-    //int currentSpeed = omxPlayer.engine.currentSpeed; // Index number - current speed from omxPlayer.engine.speeds[]
-    //int currentValue = omxPlayer.engine.speeds[currentSpeed]; // Speed value - e.g. 0.5x * DVD_PLAYSPEED_NORMAL = 500
-    int leastIndexDiff = 9999; // fix init value - Least difference between speeds[] and mapped speed value
-    int bestIndexMatch = 0; // should this be null? - index of speeds[] closest to target
+    int leastIndexDiff = 9999; // Least difference between speeds[] and mapped speed value
+    int bestIndexMatch = 0; // index of speeds[] closest to target
     int speedChanges = 0;
     
     for(int i = 0; i < omxPlayer.engine.speeds.size(); i++) {
@@ -83,10 +81,11 @@ void recurVideoPlayer::setSpeedTo(float speedValue){
         }
 
     }
+    // We are already at the correct speed, nothing to do
     if(bestIndexMatch == omxPlayer.engine.currentSpeed) {
         return;
     }
-
+    // Change ofxOMXPlayer speed until it matches selected one
     if(bestIndexMatch > omxPlayer.engine.currentSpeed) {
         do {
             omxPlayer.increaseSpeed();

--- a/src/recurVideoPlayer.cpp
+++ b/src/recurVideoPlayer.cpp
@@ -64,14 +64,48 @@ void recurVideoPlayer::setSpeedTo(float speedValue){
     else{speed = speedValue;}
     if(type == "ofxomxplayer"){
     #ifdef TARGET_RASPBERRY_PI
-    //omxPlayer.setSpeed(speed);
+    float mappedSpeedValue =  DVD_PLAYSPEED_NORMAL * speed; // Map speed to OMX ranges (1x = 1000)
+    
+    //int currentSpeed = omxPlayer.engine.currentSpeed; // Index number - current speed from omxPlayer.engine.speeds[]
+    //int currentValue = omxPlayer.engine.speeds[currentSpeed]; // Speed value - e.g. 0.5x * DVD_PLAYSPEED_NORMAL = 500
+    int leastIndexDiff = 9999; // fix init value - Least difference between speeds[] and mapped speed value
+    int bestIndexMatch = 0; // should this be null? - index of speeds[] closest to target
+    int speedChanges = 0;
+    
+    for(int i = 0; i < omxPlayer.engine.speeds.size(); i++) {
+        int thisSpeed = omxPlayer.engine.speeds[i];
+
+        int speedDiff = abs(mappedSpeedValue - thisSpeed);
+
+        if (speedDiff < leastIndexDiff) {
+            bestIndexMatch = i;
+            leastIndexDiff = speedDiff;
+        }
+
+    }
+    if(bestIndexMatch == omxPlayer.engine.currentSpeed) {
+        return;
+    }
+
+    if(bestIndexMatch > omxPlayer.engine.currentSpeed) {
+        do {
+            omxPlayer.increaseSpeed();
+            speedChanges++;
+        } while (bestIndexMatch != omxPlayer.engine.currentSpeed && speedChanges <= omxPlayer.engine.speeds.size());
+    } else if(bestIndexMatch < omxPlayer.engine.currentSpeed) {
+        do {
+            omxPlayer.decreaseSpeed();
+            speedChanges++;
+        } while (bestIndexMatch != omxPlayer.engine.currentSpeed && speedChanges <= omxPlayer.engine.speeds.size());
+    }
+
     #endif
     }
     else{
     ofPlayer.setSpeed(speed);
     }
     
-    //ofLog(OF_LOG_NOTICE, "the player speed is " + ofToString(getSpeed()) + "but it should be " + ofToString(speed));   
+    ofLog(OF_LOG_NOTICE, "Changed video player speed to " + ofToString(speedValue) + "x")  ;
 }
 void recurVideoPlayer::close(){
     if(type == "ofxomxplayer"){


### PR DESCRIPTION
When on the VIDEO page, the lower right pot controls the video playback speed, in 5 increments:
- 0.25x
- 0.5x
- 1x
- 2x
- 4x

The pot value gets mapped to these buckets, with a 2% margin on either site to prevent flapping video speeds due to pot drift on a speed bucket boundary. When the recurboy is first booted, we ignore the pot value and set the playback speed to 1x until the user actually moves the pot at least 5% in either direction.